### PR TITLE
Fix dark mode toggle visibility on mobile

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,11 +6,11 @@ import Image from "next/image";
 const Navbar = () => {
   return (
     <div>
-      <nav className="hidden md:block z-5000 fixed top-0 w-full border border-border bg-background">
-        <div className="md:py-2 pl-4 pr-11">
+      <nav className="block z-5000 fixed top-0 w-full border border-border bg-background">
+        <div className="py-2 px-4 md:px-11">
           <div className="flex justify-between h-10">
             <div className="flex items-center">
-              <div className="max-md:hidden text-xl font-semibold text-foreground">
+              <div className="text-xl font-semibold text-foreground">
                 <Image
                   src="/CLink.svg"
                   alt="CLink AI"
@@ -19,7 +19,7 @@ const Navbar = () => {
                 />
               </div>
             </div>
-            <div className="flex items-center space-x-4">
+            <div className="flex items-center space-x-2 md:space-x-4">
               <ThemeToggle />
               <Bell className="text-muted-foreground hover:text-foreground cursor-pointer transition-colors" />
               <BellDot


### PR DESCRIPTION
Make the Navbar visible on mobile screens to display the dark mode toggle and other navigation elements.

The Navbar component was previously hidden on mobile devices due to the `hidden md:block` Tailwind CSS class, which also hid the dark mode toggle button. This PR removes that class and adjusts the layout for mobile visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-6484efaf-bad3-40cf-a605-ee5ecebf5026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6484efaf-bad3-40cf-a605-ee5ecebf5026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

